### PR TITLE
Allow multiple hosts in cluster_address

### DIFF
--- a/10.1/centos-7/rootfs/libmysqlgalera.sh
+++ b/10.1/centos-7/rootfs/libmysqlgalera.sh
@@ -36,9 +36,17 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            local host=${clusterAddress#*://}
-            local host=${host%:*}
-            if ! resolveip -s "$host" >/dev/null 2>&1; then
+            local hosts
+            IFS=',' read -r -a hosts <<< ${clusterAddress#*://}
+            local foundResolvableHost = false
+            for host in hosts; do
+                local host=${host%:*}
+                if resolveip -s "$host" >/dev/null 2>&1; then
+                    foundResolvableHost = true
+                    break
+                fi
+            done
+            if [ "$foundResolvableHost" = false ]; then
                 clusterBootstrap="yes"
             fi
         fi

--- a/10.1/debian-9/rootfs/libmysqlgalera.sh
+++ b/10.1/debian-9/rootfs/libmysqlgalera.sh
@@ -36,9 +36,17 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            local host=${clusterAddress#*://}
-            local host=${host%:*}
-            if ! resolveip -s "$host" >/dev/null 2>&1; then
+            local hosts
+            IFS=',' read -r -a hosts <<< ${clusterAddress#*://}
+            local foundResolvableHost = false
+            for host in hosts; do
+                local host=${host%:*}
+                if resolveip -s "$host" >/dev/null 2>&1; then
+                    foundResolvableHost = true
+                    break
+                fi
+            done
+            if [ "$foundResolvableHost" = false ]; then
                 clusterBootstrap="yes"
             fi
         fi

--- a/10.1/ol-7/rootfs/libmysqlgalera.sh
+++ b/10.1/ol-7/rootfs/libmysqlgalera.sh
@@ -36,9 +36,17 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            local host=${clusterAddress#*://}
-            local host=${host%:*}
-            if ! resolveip -s "$host" >/dev/null 2>&1; then
+            local hosts
+            IFS=',' read -r -a hosts <<< ${clusterAddress#*://}
+            local foundResolvableHost = false
+            for host in hosts; do
+                local host=${host%:*}
+                if resolveip -s "$host" >/dev/null 2>&1; then
+                    foundResolvableHost = true
+                    break
+                fi
+            done
+            if [ "$foundResolvableHost" = false ]; then
                 clusterBootstrap="yes"
             fi
         fi

--- a/10.2/centos-7/rootfs/libmysqlgalera.sh
+++ b/10.2/centos-7/rootfs/libmysqlgalera.sh
@@ -36,9 +36,17 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            local host=${clusterAddress#*://}
-            local host=${host%:*}
-            if ! resolveip -s "$host" >/dev/null 2>&1; then
+            local hosts
+            IFS=',' read -r -a hosts <<< ${clusterAddress#*://}
+            local foundResolvableHost = false
+            for host in hosts; do
+                local host=${host%:*}
+                if resolveip -s "$host" >/dev/null 2>&1; then
+                    foundResolvableHost = true
+                    break
+                fi
+            done
+            if [ "$foundResolvableHost" = false ]; then
                 clusterBootstrap="yes"
             fi
         fi

--- a/10.2/debian-9/rootfs/libmysqlgalera.sh
+++ b/10.2/debian-9/rootfs/libmysqlgalera.sh
@@ -36,9 +36,17 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            local host=${clusterAddress#*://}
-            local host=${host%:*}
-            if ! resolveip -s "$host" >/dev/null 2>&1; then
+            local hosts
+            IFS=',' read -r -a hosts <<< ${clusterAddress#*://}
+            local foundResolvableHost = false
+            for host in hosts; do
+                local host=${host%:*}
+                if resolveip -s "$host" >/dev/null 2>&1; then
+                    foundResolvableHost = true
+                    break
+                fi
+            done
+            if [ "$foundResolvableHost" = false ]; then
                 clusterBootstrap="yes"
             fi
         fi

--- a/10.2/ol-7/rootfs/libmysqlgalera.sh
+++ b/10.2/ol-7/rootfs/libmysqlgalera.sh
@@ -36,9 +36,17 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            local host=${clusterAddress#*://}
-            local host=${host%:*}
-            if ! resolveip -s "$host" >/dev/null 2>&1; then
+            local hosts
+            IFS=',' read -r -a hosts <<< ${clusterAddress#*://}
+            local foundResolvableHost = false
+            for host in hosts; do
+                local host=${host%:*}
+                if resolveip -s "$host" >/dev/null 2>&1; then
+                    foundResolvableHost = true
+                    break
+                fi
+            done
+            if [ "$foundResolvableHost" = false ]; then
                 clusterBootstrap="yes"
             fi
         fi

--- a/10.3/centos-7/rootfs/libmysqlgalera.sh
+++ b/10.3/centos-7/rootfs/libmysqlgalera.sh
@@ -36,9 +36,17 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            local host=${clusterAddress#*://}
-            local host=${host%:*}
-            if ! resolveip -s "$host" >/dev/null 2>&1; then
+            local hosts
+            IFS=',' read -r -a hosts <<< ${clusterAddress#*://}
+            local foundResolvableHost = false
+            for host in hosts; do
+                local host=${host%:*}
+                if resolveip -s "$host" >/dev/null 2>&1; then
+                    foundResolvableHost = true
+                    break
+                fi
+            done
+            if [ "$foundResolvableHost" = false ]; then
                 clusterBootstrap="yes"
             fi
         fi

--- a/10.3/debian-9/rootfs/libmysqlgalera.sh
+++ b/10.3/debian-9/rootfs/libmysqlgalera.sh
@@ -36,9 +36,17 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            local host=${clusterAddress#*://}
-            local host=${host%:*}
-            if ! resolveip -s "$host" >/dev/null 2>&1; then
+            local hosts
+            IFS=',' read -r -a hosts <<< ${clusterAddress#*://}
+            local foundResolvableHost = false
+            for host in hosts; do
+                local host=${host%:*}
+                if resolveip -s "$host" >/dev/null 2>&1; then
+                    foundResolvableHost = true
+                    break
+                fi
+            done
+            if [ "$foundResolvableHost" = false ]; then
                 clusterBootstrap="yes"
             fi
         fi

--- a/10.3/ol-7/rootfs/libmysqlgalera.sh
+++ b/10.3/ol-7/rootfs/libmysqlgalera.sh
@@ -36,9 +36,17 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            local host=${clusterAddress#*://}
-            local host=${host%:*}
-            if ! resolveip -s "$host" >/dev/null 2>&1; then
+            local hosts
+            IFS=',' read -r -a hosts <<< ${clusterAddress#*://}
+            local foundResolvableHost = false
+            for host in hosts; do
+                local host=${host%:*}
+                if resolveip -s "$host" >/dev/null 2>&1; then
+                    foundResolvableHost = true
+                    break
+                fi
+            done
+            if [ "$foundResolvableHost" = false ]; then
                 clusterBootstrap="yes"
             fi
         fi

--- a/10.4/centos-7/rootfs/libmysqlgalera.sh
+++ b/10.4/centos-7/rootfs/libmysqlgalera.sh
@@ -36,9 +36,17 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            local host=${clusterAddress#*://}
-            local host=${host%:*}
-            if ! resolveip -s "$host" >/dev/null 2>&1; then
+            local hosts
+            IFS=',' read -r -a hosts <<< ${clusterAddress#*://}
+            local foundResolvableHost = false
+            for host in hosts; do
+                local host=${host%:*}
+                if resolveip -s "$host" >/dev/null 2>&1; then
+                    foundResolvableHost = true
+                    break
+                fi
+            done
+            if [ "$foundResolvableHost" = false ]; then
                 clusterBootstrap="yes"
             fi
         fi

--- a/10.4/debian-9/rootfs/libmysqlgalera.sh
+++ b/10.4/debian-9/rootfs/libmysqlgalera.sh
@@ -36,9 +36,17 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            local host=${clusterAddress#*://}
-            local host=${host%:*}
-            if ! resolveip -s "$host" >/dev/null 2>&1; then
+            local hosts
+            IFS=',' read -r -a hosts <<< ${clusterAddress#*://}
+            local foundResolvableHost = false
+            for host in hosts; do
+                local host=${host%:*}
+                if resolveip -s "$host" >/dev/null 2>&1; then
+                    foundResolvableHost = true
+                    break
+                fi
+            done
+            if [ "$foundResolvableHost" = false ]; then
                 clusterBootstrap="yes"
             fi
         fi

--- a/10.4/ol-7/rootfs/libmysqlgalera.sh
+++ b/10.4/ol-7/rootfs/libmysqlgalera.sh
@@ -36,9 +36,17 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            local host=${clusterAddress#*://}
-            local host=${host%:*}
-            if ! resolveip -s "$host" >/dev/null 2>&1; then
+            local hosts
+            IFS=',' read -r -a hosts <<< ${clusterAddress#*://}
+            local foundResolvableHost = false
+            for host in hosts; do
+                local host=${host%:*}
+                if resolveip -s "$host" >/dev/null 2>&1; then
+                    foundResolvableHost = true
+                    break
+                fi
+            done
+            if [ "$foundResolvableHost" = false ]; then
                 clusterBootstrap="yes"
             fi
         fi


### PR DESCRIPTION
**Description of the change**
implement simple for loop to consider cluster_address as a string of multiple comma delimited hosts. 

**Benefits**

It is considered best practice to specify all of the hosts of the cluster in the cluster_address setting so that a node is more likely to be able to reconnect to the cluster if it goes down.

**Applicable issues**

#4 

**Testing**

I tested the following cases:

- all hosts specified are resolvable (connects to existing cluster, as expected)
- no hosts specified are resolvable (bootstraps new cluster, as expected)
- 1 of the specified hosts is resolvable but N of the others are not (connects to existing cluster, as expected)
- 1 of the specified hosts contains a `:port` suffix (ignores the suffix when calling `resolveip`, as expected)
