### PR TITLE
Added override for wsrep_node_address from env var

### DIFF
--- a/10.1/ol-7/rootfs/libmysqlgalera.sh
+++ b/10.1/ol-7/rootfs/libmysqlgalera.sh
@@ -23,7 +23,7 @@
 mysql_extra_flags() {
     local dbExtraFlags
     read -r -a dbExtraFlags <<< "$(get_env_var_value EXTRA_FLAGS)"
-    dbExtraFlags+=("--wsrep_cluster_name=$DB_GALERA_CLUSTER_NAME" "--wsrep_node_name=$(hostname)" "--wsrep_node_address=$(hostname -i)" "--wsrep_cluster_address=$DB_GALERA_CLUSTER_ADDRESS" "--wsrep_sst_method=mariabackup" "--wsrep_sst_auth=$DB_GALERA_MARIABACKUP_USER:$DB_GALERA_MARIABACKUP_PASSWORD")
+    dbExtraFlags+=("--wsrep_cluster_name=$DB_GALERA_CLUSTER_NAME" "--wsrep_node_name=$(hostname)" "--wsrep_node_address=$(get_node_address)" "--wsrep_cluster_address=$DB_GALERA_CLUSTER_ADDRESS" "--wsrep_sst_method=mariabackup" "--wsrep_sst_auth=$DB_GALERA_MARIABACKUP_USER:$DB_GALERA_MARIABACKUP_PASSWORD")
     echo "${dbExtraFlags[@]}"
 }
 
@@ -108,6 +108,7 @@ DB_LDAP_NSS_INITGROUPS_IGNOREUSERS="$(get_env_var_value LDAP_NSS_INITGROUPS_IGNO
 export DB_LDAP_NSS_INITGROUPS_IGNOREUSERS="${DB_LDAP_NSS_INITGROUPS_IGNOREUSERS:-root,nslcd}"
 export DB_LDAP_SCOPE="$(get_env_var_value LDAP_SCOPE)"
 export DB_LDAP_TLS_REQCERT="$(get_env_var_value LDAP_TLS_REQCERT)"
+export DB_GALERA_NODE_ADDRESS="$(get_env_var_value GALERA_NODE_ADDRESS)"
 read -r -a DB_EXTRA_FLAGS <<< "$(mysql_extra_flags)"
 export DB_EXTRA_FLAGS
 EOF
@@ -927,3 +928,21 @@ mysql_ensure_optional_database_exists() {
 mysql_flag_initialized() {
     touch "$DB_VOLUME_DIR"/.mysql_initialized
 }
+
+########################
+# Check for user override of wsrep_node_address.
+# Globals:
+#   DB_*
+# Arguments:
+#   None
+# Returns:
+#   String with node address
+#########################
+get_node_address() {
+    if [[ -n "$DB_GALERA_NODE_ADDRESS" ]]; then
+        echo "$DB_GALERA_NODE_ADDRESS"
+    else
+        hostname -i
+    fi
+}
+

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ A **zero downtime** MariaDB Galera [replication](https://dev.mysql.com/doc/refma
 
  - `MARIADB_GALERA_CLUSTER_ADDRESS`: Galera cluster address to join. Defaults to `gcomm://` on a bootstrap node.
 
- - `MARIADB_GALERA_NODE_ADDRESS`: Node address to report to the Galera cluster. Defaults to `eth0 address inside container.
+ - `MARIADB_GALERA_NODE_ADDRESS`: Node address to report to the Galera cluster. Defaults to eth0 address inside container.
 
  - `MARIADB_GALERA_MARIABACKUP_USER`: [mariabackup](https://mariadb.com/kb/en/library/mariabackup-overview/) username for [State Snapshot Transfer(SST)](https://galeracluster.com/library/documentation/glossary.html#term-state-snapshot-transfer). Defaults to `mariabackup`.
 

--- a/README.md
+++ b/README.md
@@ -376,6 +376,8 @@ A **zero downtime** MariaDB Galera [replication](https://dev.mysql.com/doc/refma
 
  - `MARIADB_GALERA_CLUSTER_ADDRESS`: Galera cluster address to join. Defaults to `gcomm://` on a bootstrap node.
 
+ - `MARIADB_GALERA_NODE_ADDRESS`: Node address to report to the Galera cluster. Defaults to `eth0 address inside container.
+
  - `MARIADB_GALERA_MARIABACKUP_USER`: [mariabackup](https://mariadb.com/kb/en/library/mariabackup-overview/) username for [State Snapshot Transfer(SST)](https://galeracluster.com/library/documentation/glossary.html#term-state-snapshot-transfer). Defaults to `mariabackup`.
 
  - `MARIADB_GALERA_MARIABACKUP_PASSWORD`: [mariabackup](https://mariadb.com/kb/en/library/mariabackup-overview/) password for SST. No defaults.


### PR DESCRIPTION
Updated all 8 copies of libmysqlgalera.sh to support a wsrep_node_address override from an environment variable called MARIADB_GALERA_NODE_ADDRESS.  If it is not defined, it uses `hostname -i` as prior to this change.