### PR TITLE
Wait for wsrep

### DIFF
--- a/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -836,6 +836,10 @@ mysql_start_bg() {
     # users are not configured on slave nodes during initialization due to --skip-slave-start
     wait_for_mysql
 
+    # Wait for WSREP to be ready. If WSREP is not ready, we cannot do any transactions, thus cannot
+    # create any users, and WSREP instantly kills MariaDB if doing so
+    wait_for_wsrep
+
     # Special configuration flag for system with slow disks that could take more time
     # in initializing
     if [[ -n "${DB_INIT_SLEEP_TIME}" ]]; then
@@ -860,6 +864,42 @@ wait_for_mysql() {
     if ! retry_while is_mysql_running "$retries" "$sleep_time"; then
         error "MySQL failed to start"
         return 1
+    fi
+}
+
+########################
+# Wait for WSREP to be ready to do transactions
+# Arguments:
+#   None
+# Returns:
+#   None
+########################
+wait_for_wsrep() {
+    local -r retries=300
+    local -r sleep_time=2
+    if ! retry_while is_wsrep_ready "$retries" "$sleep_time"; then
+        error "WSREP did not become ready"
+        return 1
+    fi
+}
+
+########################
+# Checks for WSREP to be ready to do transactions
+# Arguments:
+#   None
+# Returns:
+#   Boolean
+########################
+is_wsrep_ready() {
+    debug "Checking if WSREP is ready"
+    is_ready="$(mysql_execute_print_output "mysql" "root" "" "-ss" "${opts[@]:-}" <<EOF
+select VARIABLE_VALUE from information_schema.GLOBAL_STATUS where VARIABLE_NAME = 'wsrep_ready';
+EOF
+)"
+    if [[ $is_ready == 'ON' ]]; then
+        true
+    else
+        false
     fi
 }
 

--- a/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -897,8 +897,10 @@ select VARIABLE_VALUE from information_schema.GLOBAL_STATUS where VARIABLE_NAME 
 EOF
 )"
     if [[ $is_ready == 'ON' ]]; then
+        debug "WSREP status $is_ready"
         true
     else
+        debug "WSREP status $is_ready"
         false
     fi
 }

--- a/10.3/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.3/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -836,6 +836,10 @@ mysql_start_bg() {
     # users are not configured on slave nodes during initialization due to --skip-slave-start
     wait_for_mysql
 
+    # Wait for WSREP to be ready. If WSREP is not ready, we cannot do any transactions, thus cannot
+    # create any users, and WSREP instantly kills MariaDB if doing so
+    wait_for_wsrep
+
     # Special configuration flag for system with slow disks that could take more time
     # in initializing
     if [[ -n "${DB_INIT_SLEEP_TIME}" ]]; then
@@ -860,6 +864,42 @@ wait_for_mysql() {
     if ! retry_while is_mysql_running "$retries" "$sleep_time"; then
         error "MySQL failed to start"
         return 1
+    fi
+}
+
+########################
+# Wait for WSREP to be ready to do transactions
+# Arguments:
+#   None
+# Returns:
+#   None
+########################
+wait_for_wsrep() {
+    local -r retries=300
+    local -r sleep_time=2
+    if ! retry_while is_wsrep_ready "$retries" "$sleep_time"; then
+        error "WSREP did not become ready"
+        return 1
+    fi
+}
+
+########################
+# Checks for WSREP to be ready to do transactions
+# Arguments:
+#   None
+# Returns:
+#   Boolean
+########################
+is_wsrep_ready() {
+    debug "Checking if WSREP is ready"
+    is_ready="$(mysql_execute_print_output "mysql" "root" "" "-ss" "${opts[@]:-}" <<EOF
+select VARIABLE_VALUE from information_schema.GLOBAL_STATUS where VARIABLE_NAME = 'wsrep_ready';
+EOF
+)"
+    if [[ $is_ready == 'ON' ]]; then
+        true
+    else
+        false
     fi
 }
 

--- a/10.3/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.3/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -897,8 +897,10 @@ select VARIABLE_VALUE from information_schema.GLOBAL_STATUS where VARIABLE_NAME 
 EOF
 )"
     if [[ $is_ready == 'ON' ]]; then
+        debug "WSREP status $is_ready"
         true
     else
+        debug "WSREP status $is_ready"
         false
     fi
 }

--- a/10.4/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.4/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -836,6 +836,10 @@ mysql_start_bg() {
     # users are not configured on slave nodes during initialization due to --skip-slave-start
     wait_for_mysql
 
+    # Wait for WSREP to be ready. If WSREP is not ready, we cannot do any transactions, thus cannot
+    # create any users, and WSREP instantly kills MariaDB if doing so
+    wait_for_wsrep
+
     # Special configuration flag for system with slow disks that could take more time
     # in initializing
     if [[ -n "${DB_INIT_SLEEP_TIME}" ]]; then
@@ -860,6 +864,42 @@ wait_for_mysql() {
     if ! retry_while is_mysql_running "$retries" "$sleep_time"; then
         error "MySQL failed to start"
         return 1
+    fi
+}
+
+########################
+# Wait for WSREP to be ready to do transactions
+# Arguments:
+#   None
+# Returns:
+#   None
+########################
+wait_for_wsrep() {
+    local -r retries=300
+    local -r sleep_time=2
+    if ! retry_while is_wsrep_ready "$retries" "$sleep_time"; then
+        error "WSREP did not become ready"
+        return 1
+    fi
+}
+
+########################
+# Checks for WSREP to be ready to do transactions
+# Arguments:
+#   None
+# Returns:
+#   Boolean
+########################
+is_wsrep_ready() {
+    debug "Checking if WSREP is ready"
+    is_ready="$(mysql_execute_print_output "mysql" "root" "" "-ss" "${opts[@]:-}" <<EOF
+select VARIABLE_VALUE from information_schema.GLOBAL_STATUS where VARIABLE_NAME = 'wsrep_ready';
+EOF
+)"
+    if [[ $is_ready == 'ON' ]]; then
+        true
+    else
+        false
     fi
 }
 

--- a/10.4/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.4/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -897,8 +897,10 @@ select VARIABLE_VALUE from information_schema.GLOBAL_STATUS where VARIABLE_NAME 
 EOF
 )"
     if [[ $is_ready == 'ON' ]]; then
+        debug "WSREP status $is_ready"
         true
     else
+        debug "WSREP status $is_ready"
         false
     fi
 }

--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -836,6 +836,10 @@ mysql_start_bg() {
     # users are not configured on slave nodes during initialization due to --skip-slave-start
     wait_for_mysql
 
+    # Wait for WSREP to be ready. If WSREP is not ready, we cannot do any transactions, thus cannot
+    # create any users, and WSREP instantly kills MariaDB if doing so
+    wait_for_wsrep
+
     # Special configuration flag for system with slow disks that could take more time
     # in initializing
     if [[ -n "${DB_INIT_SLEEP_TIME}" ]]; then
@@ -860,6 +864,42 @@ wait_for_mysql() {
     if ! retry_while is_mysql_running "$retries" "$sleep_time"; then
         error "MySQL failed to start"
         return 1
+    fi
+}
+
+########################
+# Wait for WSREP to be ready to do transactions
+# Arguments:
+#   None
+# Returns:
+#   None
+########################
+wait_for_wsrep() {
+    local -r retries=300
+    local -r sleep_time=2
+    if ! retry_while is_wsrep_ready "$retries" "$sleep_time"; then
+        error "WSREP did not become ready"
+        return 1
+    fi
+}
+
+########################
+# Checks for WSREP to be ready to do transactions
+# Arguments:
+#   None
+# Returns:
+#   Boolean
+########################
+is_wsrep_ready() {
+    debug "Checking if WSREP is ready"
+    is_ready="$(mysql_execute_print_output "mysql" "root" "" "-ss" "${opts[@]:-}" <<EOF
+select VARIABLE_VALUE from information_schema.GLOBAL_STATUS where VARIABLE_NAME = 'wsrep_ready';
+EOF
+)"
+    if [[ $is_ready == 'ON' ]]; then
+        true
+    else
+        false
     fi
 }
 

--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -897,8 +897,10 @@ select VARIABLE_VALUE from information_schema.GLOBAL_STATUS where VARIABLE_NAME 
 EOF
 )"
     if [[ $is_ready == 'ON' ]]; then
+        debug "WSREP status $is_ready"
         true
     else
+        debug "WSREP status $is_ready"
         false
     fi
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Wait until WSREP tells that it is ready to recieve transactions

**Benefits**

on slow storages, if WSREP is not ready, but we can already connect to mariadb initial installation of users fail
because any transaction is rejected by WSREP

**Possible drawbacks**

Sometimes WSREP tells that it is ready, when in fact it is not, but that is problem with storage that is not accessible(Not slow, but plain gone)

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

It should probably even replace the need for `DB_INIT_SLEEP_TIME`

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->