### PR TITLE
Ldap search map and filter

### DIFF
--- a/10.2/debian-10/rootfs/opt/bitnami/scripts/libldapclient.sh
+++ b/10.2/debian-10/rootfs/opt/bitnami/scripts/libldapclient.sh
@@ -29,6 +29,8 @@ export LDAP_BIND_PASSWORD="${LDAP_BIND_PASSWORD:-}"
 export LDAP_BASE_LOOKUP="${LDAP_BASE_LOOKUP:-}"
 export LDAP_NSS_INITGROUPS_IGNOREUSERS="${LDAP_NSS_INITGROUPS_IGNOREUSERS:-root,nslcd}"
 export LDAP_SCOPE="${LDAP_SCOPE:-}"
+export LDAP_SEARCH_FILTER="${LDAP_SEARCH_FILTER:-}"
+export LDAP_SEARCH_MAP="${LDAP_SEARCH_MAP:-}"
 export LDAP_TLS_REQCERT="${LDAP_TLS_REQCERT:-}"
 EOF
     if [[ "$OS_FLAVOUR" =~ ^debian-.*$ ]]; then
@@ -121,6 +123,18 @@ EOF
         cat >>"/etc/nslcd.conf"<<EOF
 # The search scope
 scope $LDAP_SCOPE
+EOF
+    fi
+    if [[ -n "${LDAP_SEARCH_FILTER}" ]]; then
+        cat >>"/etc/nslcd.conf"<<EOF
+# LDAP search filter to use for posix users
+filter passwd (objectClass=$LDAP_SEARCH_FILTER)
+EOF
+    fi
+    if [[ -n "${LDAP_SEARCH_MAP}" ]]; then
+        cat >>"/etc/nslcd.conf"<<EOF
+# Used for lookup of custom attributes
+map passwd uid $LDAP_SEARCH_MAP
 EOF
     fi
     if [[ -n "${LDAP_TLS_REQCERT}" ]]; then

--- a/10.3/debian-10/rootfs/opt/bitnami/scripts/libldapclient.sh
+++ b/10.3/debian-10/rootfs/opt/bitnami/scripts/libldapclient.sh
@@ -29,6 +29,8 @@ export LDAP_BIND_PASSWORD="${LDAP_BIND_PASSWORD:-}"
 export LDAP_BASE_LOOKUP="${LDAP_BASE_LOOKUP:-}"
 export LDAP_NSS_INITGROUPS_IGNOREUSERS="${LDAP_NSS_INITGROUPS_IGNOREUSERS:-root,nslcd}"
 export LDAP_SCOPE="${LDAP_SCOPE:-}"
+export LDAP_SEARCH_FILTER="${LDAP_SEARCH_FILTER:-}"
+export LDAP_SEARCH_MAP="${LDAP_SEARCH_MAP:-}"
 export LDAP_TLS_REQCERT="${LDAP_TLS_REQCERT:-}"
 EOF
     if [[ "$OS_FLAVOUR" =~ ^debian-.*$ ]]; then
@@ -121,6 +123,18 @@ EOF
         cat >>"/etc/nslcd.conf"<<EOF
 # The search scope
 scope $LDAP_SCOPE
+EOF
+    fi
+    if [[ -n "${LDAP_SEARCH_FILTER}" ]]; then
+        cat >>"/etc/nslcd.conf"<<EOF
+# LDAP search filter to use for posix users
+filter passwd (objectClass=$LDAP_SEARCH_FILTER)
+EOF
+    fi
+    if [[ -n "${LDAP_SEARCH_MAP}" ]]; then
+        cat >>"/etc/nslcd.conf"<<EOF
+# Used for lookup of custom attributes
+map passwd uid $LDAP_SEARCH_MAP
 EOF
     fi
     if [[ -n "${LDAP_TLS_REQCERT}" ]]; then

--- a/10.4/debian-10/rootfs/opt/bitnami/scripts/libldapclient.sh
+++ b/10.4/debian-10/rootfs/opt/bitnami/scripts/libldapclient.sh
@@ -29,6 +29,8 @@ export LDAP_BIND_PASSWORD="${LDAP_BIND_PASSWORD:-}"
 export LDAP_BASE_LOOKUP="${LDAP_BASE_LOOKUP:-}"
 export LDAP_NSS_INITGROUPS_IGNOREUSERS="${LDAP_NSS_INITGROUPS_IGNOREUSERS:-root,nslcd}"
 export LDAP_SCOPE="${LDAP_SCOPE:-}"
+export LDAP_SEARCH_FILTER="${LDAP_SEARCH_FILTER:-}"
+export LDAP_SEARCH_MAP="${LDAP_SEARCH_MAP:-}"
 export LDAP_TLS_REQCERT="${LDAP_TLS_REQCERT:-}"
 EOF
     if [[ "$OS_FLAVOUR" =~ ^debian-.*$ ]]; then
@@ -121,6 +123,18 @@ EOF
         cat >>"/etc/nslcd.conf"<<EOF
 # The search scope
 scope $LDAP_SCOPE
+EOF
+    fi
+    if [[ -n "${LDAP_SEARCH_FILTER}" ]]; then
+        cat >>"/etc/nslcd.conf"<<EOF
+# LDAP search filter to use for posix users
+filter passwd (objectClass=$LDAP_SEARCH_FILTER)
+EOF
+    fi
+    if [[ -n "${LDAP_SEARCH_MAP}" ]]; then
+        cat >>"/etc/nslcd.conf"<<EOF
+# Used for lookup of custom attributes
+map passwd uid $LDAP_SEARCH_MAP
 EOF
     fi
     if [[ -n "${LDAP_TLS_REQCERT}" ]]; then

--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/libldapclient.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/libldapclient.sh
@@ -29,6 +29,8 @@ export LDAP_BIND_PASSWORD="${LDAP_BIND_PASSWORD:-}"
 export LDAP_BASE_LOOKUP="${LDAP_BASE_LOOKUP:-}"
 export LDAP_NSS_INITGROUPS_IGNOREUSERS="${LDAP_NSS_INITGROUPS_IGNOREUSERS:-root,nslcd}"
 export LDAP_SCOPE="${LDAP_SCOPE:-}"
+export LDAP_SEARCH_FILTER="${LDAP_SEARCH_FILTER:-}"
+export LDAP_SEARCH_MAP="${LDAP_SEARCH_MAP:-}"
 export LDAP_TLS_REQCERT="${LDAP_TLS_REQCERT:-}"
 EOF
     if [[ "$OS_FLAVOUR" =~ ^debian-.*$ ]]; then
@@ -121,6 +123,18 @@ EOF
         cat >>"/etc/nslcd.conf"<<EOF
 # The search scope
 scope $LDAP_SCOPE
+EOF
+    fi
+    if [[ -n "${LDAP_SEARCH_FILTER}" ]]; then
+        cat >>"/etc/nslcd.conf"<<EOF
+# LDAP search filter to use for posix users
+filter passwd (objectClass=$LDAP_SEARCH_FILTER)
+EOF
+    fi
+    if [[ -n "${LDAP_SEARCH_MAP}" ]]; then
+        cat >>"/etc/nslcd.conf"<<EOF
+# Used for lookup of custom attributes
+map passwd uid $LDAP_SEARCH_MAP
 EOF
     fi
     if [[ -n "${LDAP_TLS_REQCERT}" ]]; then

--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ LDAP configuration parameters must be specified if you wish to enable LDAP suppo
 - `LDAP_BASE_LOOKUP`: LDAP base lookup (Optional). No defaults.
 - `LDAP_NSS_INITGROUPS_IGNOREUSERS`: LDAP ignored users. Defaults to `root,nslcd`.
 - `LDAP_SCOPE`: LDAP search scope (Optional). No defaults.
+- `LDAP_SEARCH_FILTER`: LDAP search filter on posix users (Optional). No defaults.
+- `LDAP_SEARCH_MAP`: LDAP custom search attribute to be looked up on posix users (Optional). No defaults.
 - `LDAP_TLS_REQCERT`: LDAP TLS check on server certificates (Optional). No defaults.
 
 ### Step 1: Start MariaDB Galera with LDAP support


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This change adds MAP and FILTER search options.

**Benefits**

Having more options and granularity for non-standard LDAP searches

**Possible drawbacks**

Works only for the `passwd` map (posix users) - which is already the default BASE_LOOKUP map for this repo anyway.

**Applicable issues**

N/A

**Additional information**

The relevant Helm chart (https://github.com/bitnami/charts/tree/master/bitnami/mariadb-galera at https://github.com/bitnami/charts/blob/eaffdc080719c891827aad846dd8d35baaaefd40/bitnami/mariadb-galera/values.yaml#L224) will need to be updated to include the new parameters for consistency. Will open a PR for that too if this gets merged
