### PR TITLE
Only bootstrap node if a name was resolved

### DIFF
--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -104,7 +104,6 @@ get_galera_cluster_bootstrap_value() {
         if [[ -z "$clusterAddress" ]]; then
             clusterBootstrap="yes"
         elif [[ -n "$clusterAddress" ]]; then
-            clusterBootstrap="yes"
             local_ip=$(hostname -i)
             read -r -a hosts <<< "$(tr ',' ' ' <<< "${clusterAddress#*://}")"
             if [[ "${#hosts[@]}" -eq "1" ]]; then
@@ -117,7 +116,9 @@ get_galera_cluster_bootstrap_value() {
             else
                 for host in "${hosts[@]}"; do
                     host_ip=$(getent hosts "${host%:*}" | awk '{print $1}')
-                    if [[ -n "$host_ip" ]] && [[ "$host_ip" != "$local_ip" ]]; then
+                    if [[ -n "$host_ip" ]] && [[ "$host_ip" == "$local_ip" ]]; then
+                        clusterBootstrap="yes"
+                    else
                         clusterBootstrap="no"
                     fi
                 done

--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -109,10 +109,10 @@ get_galera_cluster_bootstrap_value() {
             read -r -a hosts <<< "$(tr ',' ' ' <<< "${clusterAddress#*://}")"
             if [[ "${#hosts[@]}" -eq "1" ]]; then
                 read -r -a cluster_ips <<< "$(getent hosts "${hosts[0]}" | awk '{print $1}' | tr '\n' ' ')"
-                if [[ "${#cluster_ips[@]}" -gt "1" ]] || ( [[ "${#cluster_ips[@]}" -eq "1" ]] && [[ "${cluster_ips[0]}" != "$local_ip" ]] ) ; then
-                    clusterBootstrap="no"
-                else
+                if [[ "${#cluster_ips[@]}" -eq "1" ]] && [[ "${cluster_ips[0]}" == "$local_ip" ]] ; then
                     clusterBootstrap="yes"
+                else
+                    clusterBootstrap="no"
                 fi
             else
                 for host in "${hosts[@]}"; do


### PR DESCRIPTION
Fixes #22

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Only bootstrap a starting node if exactly one IP was resolved for the gcomm address.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Remove edge cases where an unwanted node bootstrap is triggered.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
If multiple IPs resolve to a name, no bootstrap is done. In this case a force bootstrap is required.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
#22

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
