### PR TITLE
Fix invalid command line options

### DIFF
--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -56,12 +56,12 @@ mysql_extra_flags() {
     # This is especially important for the MariaDB Galera chart, in which the 'my.cnf' configuration file is mounted by default
     if ! is_file_writable "$DB_CONF_FILE"; then
         dbExtraFlags+=(
-            "--wsrep_node_name=$(get_node_name)"
-            "--wsrep_node_address=$(get_node_address)"
-            "--wsrep_cluster_name=${DB_GALERA_CLUSTER_NAME}"
-            "--wsrep_cluster_address=$(get_galera_cluster_address_value)"
-            "--wsrep_sst_method=${DB_GALERA_SST_METHOD}"
-            "--wsrep_sst_auth=${DB_GALERA_MARIABACKUP_USER}:${DB_GALERA_MARIABACKUP_PASSWORD}"
+            "--wsrep-node-name=$(get_node_name)"
+            "--wsrep-node-address=$(get_node_address)"
+            "--wsrep-cluster-name=${DB_GALERA_CLUSTER_NAME}"
+            "--wsrep-cluster-address=$(get_galera_cluster_address_value)"
+            "--wsrep-sst-method=${DB_GALERA_SST_METHOD}"
+            "--wsrep-sst-auth=${DB_GALERA_MARIABACKUP_USER}:${DB_GALERA_MARIABACKUP_PASSWORD}"
         )
     fi
 


### PR DESCRIPTION
Description of the change

use valid command line options with dashes. (underscore is for system variables)

Benefits
Make it possible for a node to join the cluster after crash by receiving a SST.
Make mariabackup successful so that the donor node can stream to the joining node.

Possible drawbacks

none

Applicable issues
none

Additional information

when wsrep_sst_method is set to mariabackup, the donor node makes a backup with mariabackup, then streams to the joining node. Variables with underscores are invalid as command line options, cause mariabackup to fail on the donor node and disconnect from the joining node. This is the culprit of nodes failing to join the cluster after a crash. The log of the joining node only indicates this is a network connection issue. The joining node waits for streaming of write sets which never happens. When mariabackup is successful with revised valid command line options, failed nodes can receive streaming of write sets and can join the cluster successfully.