### PR TITLE
fixed bootstrap parameter not included in docker command shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ $ docker run -d --name mariadb-galera-0 \
   -e MARIADB_GALERA_CLUSTER_NAME=my_galera \
   -e MARIADB_GALERA_MARIABACKUP_USER=my_mariabackup_user \
   -e MARIADB_GALERA_MARIABACKUP_PASSWORD=my_mariabackup_password \
+  -e MARIADB_GALERA_CLUSTER_BOOTSTRAP=yes \
   -e MARIADB_ROOT_PASSWORD=my_root_password \
   -e MARIADB_USER=my_user \
   -e MARIADB_PASSWORD=my_password \


### PR DESCRIPTION
**Description of the change**

Added **MARIADB_GALERA_CLUSTER_BOOTSTRAP=yes** in Read me file. This was missing in the docker command shown but was mentioned in the description.

**Benefits**

This change will let the user run the exact command mentioned in the description with proper bootstrapping of the Galera node.

**Possible drawbacks**

There are no drawbacks.

**Applicable issues**

None
