### PR TITLE
change /opt/bitnami to /bitnami in all version envs to match charts config update

### DIFF
--- a/10.2/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.2/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -11,7 +11,7 @@
 # Load logging library
 . /opt/bitnami/scripts/liblog.sh
 
-export BITNAMI_ROOT_DIR="/opt/bitnami"
+export BITNAMI_ROOT_DIR="/bitnami"
 export BITNAMI_VOLUME_DIR="/bitnami"
 
 # Logging configuration

--- a/10.3/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.3/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -11,7 +11,7 @@
 # Load logging library
 . /opt/bitnami/scripts/liblog.sh
 
-export BITNAMI_ROOT_DIR="/opt/bitnami"
+export BITNAMI_ROOT_DIR="/bitnami"
 export BITNAMI_VOLUME_DIR="/bitnami"
 
 # Logging configuration

--- a/10.4/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.4/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -11,7 +11,7 @@
 # Load logging library
 . /opt/bitnami/scripts/liblog.sh
 
-export BITNAMI_ROOT_DIR="/opt/bitnami"
+export BITNAMI_ROOT_DIR="/bitnami"
 export BITNAMI_VOLUME_DIR="/bitnami"
 
 # Logging configuration

--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -11,7 +11,7 @@
 # Load logging library
 . /opt/bitnami/scripts/liblog.sh
 
-export BITNAMI_ROOT_DIR="/opt/bitnami"
+export BITNAMI_ROOT_DIR="/bitnami"
 export BITNAMI_VOLUME_DIR="/bitnami"
 
 # Logging configuration


### PR DESCRIPTION
**Description**

Change the `BITNAMI_ROOT_DIR` in all `mariadb-env.sh` files.


**Benefits**

bitnami/charts#6567 recently changed the default directory to which configuration files are mounted, but the underlying MariaDB instance is still reading from `/opt/bitnami/conf` instead of `/bitnami/conf`. This change normalises this behaviour across both repos.

**Possible drawbacks**

AFAIK, none, as all config dirs are relatively linked using the base env `BITNAMI_ROOT_DIR`, and hence this should not break anything.

