### PR TITLE
Add support for dual stack usage

### DIFF
--- a/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.2/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -154,7 +154,7 @@ has_galera_cluster_other_nodes() {
         has_nodes="no"
     elif [[ -n "$cluster_address" ]]; then
         has_nodes="no"
-        local_ip=$(hostname -i)
+        read -r -a local_ips <<< "$(hostname -i)"
         read -r -a addresses <<< "$(tr ',' ' ' <<< "${cluster_address#*://}")"
         if [[ "${#addresses[@]}" -eq "1" ]]; then
             if validate_ipv4 "$(echo "${addresses[0]}" | cut -d':' -f1)"; then
@@ -176,9 +176,19 @@ has_galera_cluster_other_nodes() {
                 else
                     is_hostname_resolved "$address" && node_ip="$(dns_lookup "$address")"
                 fi
-                if [[ -n "$node_ip" ]] && [[ "$node_ip" != "$local_ip" ]]; then
+                if [[ -n "$node_ip" ]]; then
                     has_nodes="yes"
-                    break
+                    # we now check if *any* of our IPs matches the node IP. In that case, we have to revert has_nodes to no, because it's not in fact a foreign node and check the next.
+                    for local_ip in "${local_ips[@]}"; do
+                        if [[ "$node_ip" == "$local_ip" ]]; then
+                            has_nodes="no"
+                            break
+                        fi
+                    done
+                    # The foreign IP did not match our local IP, so we know that another node exists.
+                    if [[ "$has_nodes" == 'yes' ]]; then
+                        break
+                    fi
                 fi
             done
         fi
@@ -723,7 +733,9 @@ get_node_address() {
         local -r retries="60"
         local -r seconds="5"
         retry_while "hostname -i" "$retries" "$seconds" >/dev/null
-        hostname -i
+        # prefer IPv6 over IPv4 if available
+        # This works by pulling any IPv4 addresses encountered into hold space and emitting it only when the EOF line is encountered
+        printf '%s\nEOF' "$(hostname -i | tr ' ' '\n')" | sed '/:/{;q;};/^EOF$/{;g;q;};h;d'
     fi
 }
 

--- a/10.3/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.3/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -154,7 +154,7 @@ has_galera_cluster_other_nodes() {
         has_nodes="no"
     elif [[ -n "$cluster_address" ]]; then
         has_nodes="no"
-        local_ip=$(hostname -i)
+        read -r -a local_ips <<< "$(hostname -i)"
         read -r -a addresses <<< "$(tr ',' ' ' <<< "${cluster_address#*://}")"
         if [[ "${#addresses[@]}" -eq "1" ]]; then
             if validate_ipv4 "$(echo "${addresses[0]}" | cut -d':' -f1)"; then
@@ -176,9 +176,19 @@ has_galera_cluster_other_nodes() {
                 else
                     is_hostname_resolved "$address" && node_ip="$(dns_lookup "$address")"
                 fi
-                if [[ -n "$node_ip" ]] && [[ "$node_ip" != "$local_ip" ]]; then
+                if [[ -n "$node_ip" ]]; then
                     has_nodes="yes"
-                    break
+                    # we now check if *any* of our IPs matches the node IP. In that case, we have to revert has_nodes to no, because it's not in fact a foreign node and check the next.
+                    for local_ip in "${local_ips[@]}"; do
+                        if [[ "$node_ip" == "$local_ip" ]]; then
+                            has_nodes="no"
+                            break
+                        fi
+                    done
+                    # The foreign IP did not match our local IP, so we know that another node exists.
+                    if [[ "$has_nodes" == 'yes' ]]; then
+                        break
+                    fi
                 fi
             done
         fi
@@ -723,7 +733,9 @@ get_node_address() {
         local -r retries="60"
         local -r seconds="5"
         retry_while "hostname -i" "$retries" "$seconds" >/dev/null
-        hostname -i
+        # prefer IPv6 over IPv4 if available
+        # This works by pulling any IPv4 addresses encountered into hold space and emitting it only when the EOF line is encountered
+        printf '%s\nEOF' "$(hostname -i | tr ' ' '\n')" | sed '/:/{;q;};/^EOF$/{;g;q;};h;d'
     fi
 }
 

--- a/10.4/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.4/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -154,7 +154,7 @@ has_galera_cluster_other_nodes() {
         has_nodes="no"
     elif [[ -n "$cluster_address" ]]; then
         has_nodes="no"
-        local_ip=$(hostname -i)
+        read -r -a local_ips <<< "$(hostname -i)"
         read -r -a addresses <<< "$(tr ',' ' ' <<< "${cluster_address#*://}")"
         if [[ "${#addresses[@]}" -eq "1" ]]; then
             if validate_ipv4 "$(echo "${addresses[0]}" | cut -d':' -f1)"; then
@@ -176,9 +176,19 @@ has_galera_cluster_other_nodes() {
                 else
                     is_hostname_resolved "$address" && node_ip="$(dns_lookup "$address")"
                 fi
-                if [[ -n "$node_ip" ]] && [[ "$node_ip" != "$local_ip" ]]; then
+                if [[ -n "$node_ip" ]]; then
                     has_nodes="yes"
-                    break
+                    # we now check if *any* of our IPs matches the node IP. In that case, we have to revert has_nodes to no, because it's not in fact a foreign node and check the next.
+                    for local_ip in "${local_ips[@]}"; do
+                        if [[ "$node_ip" == "$local_ip" ]]; then
+                            has_nodes="no"
+                            break
+                        fi
+                    done
+                    # The foreign IP did not match our local IP, so we know that another node exists.
+                    if [[ "$has_nodes" == 'yes' ]]; then
+                        break
+                    fi
                 fi
             done
         fi
@@ -723,7 +733,9 @@ get_node_address() {
         local -r retries="60"
         local -r seconds="5"
         retry_while "hostname -i" "$retries" "$seconds" >/dev/null
-        hostname -i
+        # prefer IPv6 over IPv4 if available
+        # This works by pulling any IPv4 addresses encountered into hold space and emitting it only when the EOF line is encountered
+        printf '%s\nEOF' "$(hostname -i | tr ' ' '\n')" | sed '/:/{;q;};/^EOF$/{;g;q;};h;d'
     fi
 }
 

--- a/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -154,7 +154,7 @@ has_galera_cluster_other_nodes() {
         has_nodes="no"
     elif [[ -n "$cluster_address" ]]; then
         has_nodes="no"
-        local_ip=$(hostname -i)
+        read -r -a local_ips <<< "$(hostname -i)"
         read -r -a addresses <<< "$(tr ',' ' ' <<< "${cluster_address#*://}")"
         if [[ "${#addresses[@]}" -eq "1" ]]; then
             if validate_ipv4 "$(echo "${addresses[0]}" | cut -d':' -f1)"; then
@@ -176,9 +176,19 @@ has_galera_cluster_other_nodes() {
                 else
                     is_hostname_resolved "$address" && node_ip="$(dns_lookup "$address")"
                 fi
-                if [[ -n "$node_ip" ]] && [[ "$node_ip" != "$local_ip" ]]; then
+                if [[ -n "$node_ip" ]]; then
                     has_nodes="yes"
-                    break
+                    # we now check if *any* of our IPs matches the node IP. In that case, we have to revert has_nodes to no, because it's not in fact a foreign node and check the next.
+                    for local_ip in "${local_ips[@]}"; do
+                        if [[ "$node_ip" == "$local_ip" ]]; then
+                            has_nodes="no"
+                            break
+                        fi
+                    done
+                    # The foreign IP did not match our local IP, so we know that another node exists.
+                    if [[ "$has_nodes" == 'yes' ]]; then
+                        break
+                    fi
                 fi
             done
         fi
@@ -723,7 +733,9 @@ get_node_address() {
         local -r retries="60"
         local -r seconds="5"
         retry_while "hostname -i" "$retries" "$seconds" >/dev/null
-        hostname -i
+        # prefer IPv6 over IPv4 if available
+        # This works by pulling any IPv4 addresses encountered into hold space and emitting it only when the EOF line is encountered
+        printf '%s\nEOF' "$(hostname -i | tr ' ' '\n')" | sed '/:/{;q;};/^EOF$/{;g;q;};h;d'
     fi
 }
 

--- a/10.6/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/10.6/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -154,7 +154,7 @@ has_galera_cluster_other_nodes() {
         has_nodes="no"
     elif [[ -n "$cluster_address" ]]; then
         has_nodes="no"
-        local_ip=$(hostname -i)
+        read -r -a local_ips <<< "$(hostname -i)"
         read -r -a addresses <<< "$(tr ',' ' ' <<< "${cluster_address#*://}")"
         if [[ "${#addresses[@]}" -eq "1" ]]; then
             if validate_ipv4 "$(echo "${addresses[0]}" | cut -d':' -f1)"; then
@@ -176,9 +176,19 @@ has_galera_cluster_other_nodes() {
                 else
                     is_hostname_resolved "$address" && node_ip="$(dns_lookup "$address")"
                 fi
-                if [[ -n "$node_ip" ]] && [[ "$node_ip" != "$local_ip" ]]; then
+                if [[ -n "$node_ip" ]]; then
                     has_nodes="yes"
-                    break
+                    # we now check if *any* of our IPs matches the node IP. In that case, we have to revert has_nodes to no, because it's not in fact a foreign node and check the next.
+                    for local_ip in "${local_ips[@]}"; do
+                        if [[ "$node_ip" == "$local_ip" ]]; then
+                            has_nodes="no"
+                            break
+                        fi
+                    done
+                    # The foreign IP did not match our local IP, so we know that another node exists.
+                    if [[ "$has_nodes" == 'yes' ]]; then
+                        break
+                    fi
                 fi
             done
         fi
@@ -723,7 +733,9 @@ get_node_address() {
         local -r retries="60"
         local -r seconds="5"
         retry_while "hostname -i" "$retries" "$seconds" >/dev/null
-        hostname -i
+        # prefer IPv6 over IPv4 if available
+        # This works by pulling any IPv4 addresses encountered into hold space and emitting it only when the EOF line is encountered
+        printf '%s\nEOF' "$(hostname -i | tr ' ' '\n')" | sed '/:/{;q;};/^EOF$/{;g;q;};h;d'
     fi
 }
 


### PR DESCRIPTION
**Description of the change**

This adapts the code according to the multi-valued output of `hostname -i` on dual stack setups.

In dual stack (IPv4+IPv6) setups, `hostname -i` returns multiple IP
addresses (on all my tests, IPv6 came first, by the way).

This caused two issues:

1. The `has_galera_cluster_other_nodes` check broke because
   `hostname -i` returned two space-separated IP addresses, which caused
   the check for whether the first `cluster_ips` entry (always a single
   IP) matched `local_ip` to always be false.

   This is fixed by using word splitting on the `hostname -i` result,
   reading it into an array and check each IP.

2. The `get_node_address` function returned the `hostname -i` result
   verbatimly. Its output is used in the wsrep-node-address argument,
   which is then later on passed through word splitting again. That
   causes mysqld to be called with an unexpected positional argument.

   To avoid this, the IP addresses returned by hostname are sorted and
   the first address is selected, preferring IPv6 over IPv4.

**Benefits**

Single- and multi-node clusters can now be spawned on Kubernetes with Dualstack enabled.

**Possible drawbacks**

A setup with dualstack but broken IPv6 will not work correctly, as IPv6 is preferred over IPv4. This is a deliberate choice.

**Applicable issues**

See above (no issues filed as this sprang from ad-hoc debugging).

**Additional information**

I am not quite sure if this addresses all possible setups. I could imagine `getent hosts` returning multiple addresses per peer, too, which would very much complicate the logic there. Haven't encountered that yet though.

I tested this in our setup based on 10.2.41-debian-10-r11 and it works like a charm (bootstrapping, clustering and rolling upgrades via statefulset tested)

---

This is a reopen of #62, as I seem to lack the permissions/options to re-open the PR with new commits. Sorry for letting that one expire, github notifications are complicated as mentioned.

This should address the comments raised by making the IPv6/IPv4 sort locale- and configuration-indepentent as well as a rebase on current master.